### PR TITLE
Use union type instead of enum for OfferType

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -128,9 +128,7 @@ export namespace PublicOfferV2 {
     pets?: Array<string | undefined>;
   }
 
-  enum OfferType {
-    BedbankHotel = "bedbank_hotel"
-  }
+  type OfferType = "bedbank_hotel" | "hotel";
 
   interface Property {
     id: string;


### PR DESCRIPTION
Turns out you can't use enums in declaration files.

https://lukasbehal.com/2017-05-22-enums-in-declaration-files/

Makes sense since an enum is more than a type, it can be used at runtime, hence has to go in a .ts file.

Not sure of the best way to do this, so have opted for a union type for now, and we can figure out how to support enums through this module separately.