### PR TITLE
KAN-1150 add types for refunds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -6,6 +6,7 @@ export namespace Order {
   interface OrderLinks {
     self: Link;
     payments: Link;
+    refunds: Link;
     status: Link;
   }
 
@@ -264,5 +265,20 @@ export namespace Order {
     account_id: string;
     first_name: string;
     last_name: string;
+  }
+
+  interface Refund {
+    item_id: string;
+    amount: string;
+    refund_method: string;
+    created_at: string;
+    refund_fee: string;
+    accounting_amount: string;
+  }
+
+  interface RefundResult {
+    message: string;
+    status: number;
+    result: Refund[];
   }
 }


### PR DESCRIPTION
[Ticket](https://aussiecommerce.atlassian.net/browse/KAN-1150?atlOrigin=eyJpIjoiOTNlY2ZlYzI5YTljNGRlY2I2YzRiOTk3MzU3MTk2NTIiLCJwIjoiaiJ9)

Add types for refunds api call: `/api/orders/_orderId_/refunds.`