### PR TITLE
Remove discount from option

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -86,6 +86,7 @@ export namespace PublicOfferV2 {
 
   interface RatePlan {
     id: string;
+    discount: number;
     cancellationPolicy: {
       type: LeCancellationPolicyType;
       description: Array<string>;

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -108,7 +108,6 @@ export namespace PublicOfferV2 {
     value?: number;
     currencyCode: string;
     price?: number;
-    discount?: number;
     trackingPrice?: number;
   }
 

--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -142,6 +142,7 @@ export namespace Reservation {
     id: string;
     id_salesforce_external: string;
     name: string;
+    discount: number;
     default_plan: boolean;
     cancellation_policy: CancellationPolicy;
     cancellation_policy_detail?: Array<string>;


### PR DESCRIPTION
As requested by Robert:

this should be calculated on the front end as prices may affected by factors out of public offers control OR it should be the rate plan discount (e.g. for last minute escapes)- of which we have the rate plan, so no need to duplicate the field.

Add the discount percent to the rate plan