### PR TITLE
public-offers/list required params

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -487,7 +487,7 @@ export namespace PublicOfferV2 {
     checkIn: string;
     checkOut: string;
     region?: string;
-    brand?: string;
+    brand: string;
     offerType?: OfferType;
     flightOrigin?: string;
   }

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -486,9 +486,9 @@ export namespace PublicOfferV2 {
     occupancy: Array<string> | string;
     checkIn: string;
     checkOut: string;
-    region?: string;
+    region: string;
     brand: string;
-    offerType?: OfferType;
+    offerType: OfferType;
     flightOrigin?: string;
   }
 


### PR DESCRIPTION
To prove it:

```
$ curl https://api.luxuryescapes.com/api/v2/public-offers/list | jq

{
  "status": 400,
  "message": "Invalid url query parameters",
  "errors": [
    {
      "path": "offerType",
      "message": "should be a valid enum value"
    },
    {
      "path": "placeIds",
      "message": "Place ids is required"
    },
    {
      "path": "region",
      "message": "should be a string"
    },
    {
      "path": "brand",
      "message": "should be a string"
    }
  ]
}
```