### PR TITLE
[TBB-111]: add back metaDescription and attractions fields in BedbankOffer

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -387,6 +387,8 @@ export namespace PublicOfferV2 {
     type: BedbankOfferType;
     name: string;
     slug: string;
+    metaDescription: string;
+    attractions?: string;
     packages: Array<BedbankPackage>;
     images: Array<Image>;
     popularFacilities: Array<string>;


### PR DESCRIPTION
We need to keep the metaDescription and attractions fields outside of the copy in BedbankOffer. This solution is only temporal, to have time to change all the dependencies