### PR TITLE
Fix Offers and types

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -376,8 +376,8 @@ export namespace PublicOfferV2 {
 
   type LeOfferType = Exclude<OfferType, "bedbank_hotel">;
   type BedbankOfferType = Extract<OfferType, "bedbank_hotel">;
-  type LeHotelOfferType = Exclude<OfferType, "tour">;
-  type LeTourOfferType = Extract<OfferType, "tour">;
+  type LeHotelOfferType = Exclude<LeOfferType, "tour">;
+  type LeTourOfferType = Extract<LeOfferType, "tour">;
 
   type LeOffer = LeHotelOffer | LeTourOffer;
   type Offer = LeOffer | BedbankOffer;


### PR DESCRIPTION
Without this, `LeHotelOfferType` and `LeTourOfferType` will include the bedbank offer type! Spotted while reviewing https://github.com/lux-group/www-le-customer/pull/5177/files