### PR TITLE
Update v2 package inclusions format

### DIFF
--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -180,12 +180,15 @@ export namespace PublicOfferV2 {
   interface LePackageBase {
     id: string;
     name: string;
-    inclusions: { description: string; bonus: BonusInclusion[] };
+    inclusions: { 
+      description: string; 
+      highlights?: string;
+      bonus: BonusInclusion[] 
+    };
     includedGuestsLabel: string;
     sortOrder?: number;
     partnerships: PackagePartnership[];
     copy: {
-      description: string;
       roomPolicyDescription?: string;
     };
   }


### PR DESCRIPTION
Turns out that a package `copy.description` is actually a description of the **inclusions**.

Also, the existing `inclusions.description` field is actually the `highlights` field (often smaller than description), which is optionally there