### PR TITLE
Add title to Public Offer images

### DIFF
--- a/types/api/offer.d.ts
+++ b/types/api/offer.d.ts
@@ -14,5 +14,6 @@ export namespace Offer {
     offer_id_salesforce_external: string;
     id_cloudinary_external: string;
     order: number;
+    title?: string;
   }
 }

--- a/types/api/offer.d.ts
+++ b/types/api/offer.d.ts
@@ -14,6 +14,6 @@ export namespace Offer {
     offer_id_salesforce_external: string;
     id_cloudinary_external: string;
     order: number;
-    title?: string;
+    title: string | null;
   }
 }

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -23,6 +23,7 @@ export namespace PublicOfferV2 {
 
   interface Image {
     id: string;
+    title?: string;
   }
 
   interface Configuration {


### PR DESCRIPTION
Public offer images can have have a title set on them, it's used as the alt and in some cases a caption.