### PR TITLE
[OPEX-125] add heading field to offer inclusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -449,6 +449,7 @@ export namespace PublicOfferV2 {
     noIndex: boolean;
     daysBeforeCheckInChangesDisallowed: number;
     inclusions: {
+      heading?: string;
       description?: string;
       tileHeading?: string;
       tileDescription?: string;


### PR DESCRIPTION
[OPEX-125](https://aussiecommerce.atlassian.net/browse/OPEX-125)

An optional `heading` field for an offer inclusions