### PR TITLE
bump to 1.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",


### PR DESCRIPTION
https://github.com/lux-group/lib-types/pull/140 1.4.5 was already taken so it failed