### PR TITLE
Add offer fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/offer.d.ts
+++ b/types/api/offer.d.ts
@@ -15,6 +15,7 @@ export namespace Offer {
     start: string;
     end: string;
     region: string;
+    brand: string;
   }
 
   interface BaseOffer {
@@ -24,6 +25,7 @@ export namespace Offer {
     locations: string[];
     name: string;
     slug: string;
+    holiday_types: string[];
   }
 
   type AccommodationOfferType =


### PR DESCRIPTION
- svc-search needs schedule `brand` to flat schedules for all brands and regions.
- Algolia needs `holiday_types` to search by holiday types.