### PR TITLE
feat(rate-plan): add fields to rate plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -164,6 +164,8 @@ export namespace Reservation {
     inclusions: string | null;
     bonus_inclusions?: Array<BonusInclusion>;
     rate_plan_code: string | null;
+    commission: number;
+    rate_type: string;
   }
 
   interface RatePlanLinks {


### PR DESCRIPTION
It's required by ratedock. We had these fields long time ago so don't think adding these will break anything.