### PR TITLE
Fix incorrect property names in V1 offer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer.d.ts
+++ b/types/api/public-offer.d.ts
@@ -156,8 +156,8 @@ export namespace PublicOffer {
     available_for_purchase: boolean;
     flight_origin_list: string[];
     flight_cache_active: boolean;
-    whitelistedCarrierCodes?: Array<string>;
-    bundledWithFlightsOnly?: boolean;
+    whitelisted_carrier_codes?: string[];
+    bundled_with_flights_only?: boolean;
   }
 
   interface Schedule {


### PR DESCRIPTION
Fix incorrect property names in V1 offer:
- `bundledWithFlightsOnly` to `bundled_with_flights_only`
- `whitelistedCarrierCodes` to `whitelisted_carrier_codes`