### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",


### PR DESCRIPTION
Didn't double check the version bump was still valid when I merged this PR:
https://github.com/lux-group/lib-types/pull/190


This PR just bumps the lib version again