### PR TITLE
TOUR-101: Add departures and purchasable options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.12",
+  "version": "1.10.13",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -569,7 +569,7 @@ export namespace PublicOfferV2 {
 
   interface Departure {
     id: string;
-    fkSeasonId: string;
+    fkSeasonId?: string;
     startDate: string;
     startTimeLocal?: string;
     endDate: string;

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -527,14 +527,12 @@ export namespace PublicOfferV2 {
   // Used to display the default prices for all the available departure dates for an adult twin room.
   // From price and monthly prices to be calculated from this.
   interface PurchasableOption {
-    id: string;
+    priceId: string;
     roomType: string; // Multiple room types for each departure, FE will display the cheapest room type.
     guestType: "adult"; // Adult prices only, TBC.
     price: number; // Tax inclusive
     priceTaxExclusive?: number; // Tax exclusive
     fkDepartureId: string;
-    fkSeasonId: string;
-    fkTourOptionId: string;
   }
 
   interface TourOption {
@@ -550,7 +548,6 @@ export namespace PublicOfferV2 {
     endLocation?: string;
     images: Array<Image>;
     itinerary: ItineraryItem[];
-    departures: Array<Departure>;
     copy: {
       // Large chunks of text go here
       description: string;
@@ -569,7 +566,8 @@ export namespace PublicOfferV2 {
 
   interface Departure {
     id: string;
-    fkSeasonId?: string;
+    fkSeasonId: string;
+    fkTourOptionId: string;
     startDate: string;
     startTimeLocal?: string;
     endDate: string;

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -519,17 +519,17 @@ export namespace PublicOfferV2 {
     // which is required for the "Other packages for this tour" component. Refer to latest designs.
     // FE by default will display the option which has the lowest price, prices found in the options array.
     departures: Record<string, Departure>; // List of departures
-    options: Array<PurchasableOptions>;
+    options: Array<PurchasableOption>;
   }
 
   // From the designs, the purchasable options may be picked on another page.
   // Yet to be determined if this is to be part of booking flow or at the bottom of the offer page.
   // Used to display the default prices for all the available departure dates for an adult twin room.
   // From price and monthly prices to be calculated from this.
-  interface PurchasableOptions {
+  interface PurchasableOption {
     id: string;
     roomType: string; // Multiple room types for each departure, FE will display the cheapest room type.
-    travellerType: "adult"; // Adult prices only, TBC.
+    guestType: "adult"; // Adult prices only, TBC.
     price: number; // Tax inclusive
     priceTaxExclusive?: number; // Tax exclusive
     fkDepartureId: string;
@@ -550,6 +550,7 @@ export namespace PublicOfferV2 {
     endLocation?: string;
     images: Array<Image>;
     itinerary: ItineraryItem[];
+    departures: Array<Departure>;
     copy: {
       // Large chunks of text go here
       description: string;

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -35,6 +35,22 @@ export namespace Tour {
     | "costsaver"
     | "insightvacations";
 
+  export type SellingRegion = "au";
+
+  interface Departure {
+    id: string;
+    currencyCode: string;
+    endDate: string;
+    endTime?: string;
+    endTimeLocal: string;
+    sellingRegion: SellingRegion;
+    startDate: string;
+    startTime?: string;
+    startTimeLocal: string;
+    prices: Price[];
+    fkSeasonId: string;
+  }
+
   interface Image {
     id: string;
     title?: string;
@@ -48,6 +64,13 @@ export namespace Tour {
     region?: string;
   }
 
+  interface Price {
+    id: string;
+    basePrice: number;
+    roomType: string;
+    guestType: string;
+  }
+
   interface Season {
     id: string;
     fromDate: string;
@@ -56,6 +79,7 @@ export namespace Tour {
     description: string;
     images: Image[];
     itinerary: ItineraryItem[];
+    departures: Departure[];
   }
 
   interface TourOption {

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -48,7 +48,6 @@ export namespace Tour {
     startTime?: string;
     startTimeLocal: string;
     prices: Price[];
-    fkSeasonId: string;
   }
 
   interface Image {


### PR DESCRIPTION
 - Adding Departure and Price data to what svc-tour will provide
 - Small changes to the data in svc-public-tour response

Related PRs
https://github.com/lux-group/svc-public-offer/pull/1179
https://github.com/lux-group/svc-tour/pull/51