### PR TITLE
EXP-169: update version to 1.10.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.9",
+  "version": "1.10.11",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",


### PR DESCRIPTION
This PR only updates the version as the last changes failed because package.json was not updated before.