### PR TITLE
Add check in closes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.18",
+  "version": "1.10.19",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -128,6 +128,7 @@ export namespace PublicOfferV2 {
     fkRoomRateId: string;
     fkRoomTypeId: string;
     fkRatePlanId: string;
+    checkInCloses?: string;
   }
 
   interface LeTourOption extends LeOptionBase {


### PR DESCRIPTION
As @zediah suggested, I'm using `/api/v2/public-offer` to get multiple package options that svc-calendar needed instead of creating a new endpoint for the dedicated usage. 

`checkInCloses` is not in package option respond now, svc-calendar passes on this field to svc-reservation to determine if the max check in date has availability.