### PR TITLE
feat(reservation): add should instant purchase flag to rate plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.22",
+  "version": "1.10.23",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -172,6 +172,7 @@ export namespace Reservation {
     commission?: number;
     rate_type?: string;
     markup?: number;
+    should_instant_purchase?: boolean;
   }
 
   interface RatePlanLinks {


### PR DESCRIPTION
DS requires a relevant field that we should indicate if it's a pay now or pay later. We'll need this field in DS svc ts file so rate plan doesn't complain not having this field.