### PR TITLE
fix season interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.47",
+  "version": "1.10.48",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -80,8 +80,8 @@ export namespace Tour {
     toDate: string;
     name: string;
     description: string;
-    startPlace: string | null;
-    endPlace: string | null;
+    startLocation: string | null;
+    endLocation: string | null;
     countriesVisited: string[] | null;
     images: Image[];
     itinerary: ItineraryItem[];


### PR DESCRIPTION
I had incorrectly defined the season interface in the previous PR; it had `startPlace` and `endPlace` instead of `startLocation` and `endLocation`, which did not match what we want to present in `svc-tour` 