### PR TITLE
preserve brand string, introduce brandObjet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.52",
+  "version": "1.10.53",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -531,6 +531,7 @@ export namespace PublicOfferV2 {
     type: "tour_v2";
     source: Tour.Source;
     brand: Tour.Brand;
+    brandObject: Tour.BrandObject;
     tourOptions: Record<string, TourOption>; // Contains the details of the options for this offer
     // which is required for the "Other packages for this tour" component. Refer to latest designs.
     // FE by default will display the option which has the lowest price, prices found in the options array.

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -20,9 +20,16 @@ export namespace Tour {
     source: Source;
     name: string;
     brand: Brand;
+    brandObject: BrandObject;
     status: "content-approved" | "draft";
     slug: string;
     tourOptions: Array<TourOption>;
+  }
+
+  export interface BrandObject {
+    name: string;
+    code: string;
+    svcLogoId: string
   }
 
   export type Source = "ttc";

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -29,7 +29,7 @@ export namespace Tour {
   export interface BrandObject {
     name: string;
     code: string;
-    svcLogoId: string
+    svcLogoId: string;
   }
 
   export type Source = "ttc";

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -101,4 +101,3 @@ export namespace Tour {
     seasons: Array<Season>;
   }
 }
-

--- a/types/api/tour.d.ts
+++ b/types/api/tour.d.ts
@@ -34,11 +34,13 @@ export namespace Tour {
 
   export type Source = "ttc";
 
-  export interface Brand {
-    code: string;
-    name: string;
-    svcLogoId: string;
-  }
+  export type Brand =
+    | "luxurygold"
+    | "trafalgar"
+    | "contiki"
+    | "aatkings"
+    | "costsaver"
+    | "insightvacations";
 
   export type SellingRegion = "au";
 
@@ -99,3 +101,4 @@ export namespace Tour {
     seasons: Array<Season>;
   }
 }
+


### PR DESCRIPTION
In https://github.com/lux-group/svc-public-offer/pull/1261#issuecomment-1028470078 , we were requested to preserve `brand`, and introduce another object that contains brand data.