### PR TITLE
[EXP-249] add requested fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.56",
+  "version": "1.10.57",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/experiences.d.ts
+++ b/types/api/experiences.d.ts
@@ -20,7 +20,7 @@ export namespace Experiences {
     hasOfflineBooking: boolean;
     leExclusive?: boolean;
     location?: Location;
-    maxCancellationDays: number | null;
+    maxCancellationDays?: number | null; //@deprecated won't use
     maxConfirmationHours: number | null;
     maxModifyBookingDays: number | null;
     meetingPoint?: string;

--- a/types/api/experiences.d.ts
+++ b/types/api/experiences.d.ts
@@ -10,6 +10,7 @@ export namespace Experiences {
   type Offer = {
     baseRetailPrice?: Price;
     baseSalesPrice: Price;
+    bookingFee: Price;
     categories: Array<Category>;
     languages: Array<Language>;
     curationStatus?: CurationStatus;
@@ -27,6 +28,10 @@ export namespace Experiences {
     notes?: string | null;
     offlineBookingInstructions?: string;
     pickupPoints?: Array<PickupPoint>;
+    safetyInformation?: SafetyInformation;
+    inclusions?: Array<Taxonomy>;
+    exclusions?: Array<Taxonomy>;
+    highlights?: Array<Taxonomy>;
     providerRating?: ProviderRating;
     purchaseLimit?: Range<number>;
     duration?: Range<number>;
@@ -36,6 +41,8 @@ export namespace Experiences {
     shortDescription: string | null;
     status: string;
     title: string;
+    operationalDays: string | null;
+    rememberNote: string | null;
   };
 
   type Item = {
@@ -110,6 +117,28 @@ export namespace Experiences {
     id: string;
   } & Location;
 
+  type SafetyMeasure = {
+    name: string;
+    isActive: boolean;
+  };
+
+  type SafetyInformation = {
+    measures: Array<SafetyMeasure>;
+  };
+
+  type Taxonomy = {
+    label: string;
+    category: string;
+  };
+
+  type RefundPolicy = {
+    id: string;
+    period: number;
+    type: "PERCENTAGE" | "ABSOLUTE";
+    value: number;
+    currencyCode?: string;
+  };
+
   type Language = {
     code: string;
     name: string;
@@ -124,6 +153,7 @@ export namespace Experiences {
 
   type CancellationInfo = {
     isFree: boolean;
+    refundPolicies?: RefundPolicy[];
   };
 
   type ProviderRating = {


### PR DESCRIPTION
Just added a few fields that are displayed in the new Experiences UI


Brother PR: https://github.com/lux-group/svc-connection-musement/pull/30