### PR TITLE
[OPEX-387] add new cancellation policy, partner policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.79",
+  "version": "1.10.80",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -107,7 +107,8 @@ export namespace PublicOfferV2 {
     | "prior-to-check-in-sixty-days"
     | "post-purchase-seven-days"
     | "dynamic"
-    | "credit-only-prior-to-check-in-fourteen-days";
+    | "credit-only-prior-to-check-in-fourteen-days"
+    | "partner-policy-prior-to-check-in-twenty-one-days";
 
   interface RatePlanGroup {
     id: string;

--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -158,7 +158,8 @@ export namespace Reservation {
     | "prior-to-check-in-sixty-days"
     | "post-purchase-seven-days"
     | "dynamic"
-    | "credit-only-prior-to-check-in-fourteen-days";
+    | "credit-only-prior-to-check-in-fourteen-days"
+    | "partner-policy-prior-to-check-in-twenty-one-days";
 
   interface BonusInclusion {
     id: string;


### PR DESCRIPTION
[Ticket](https://aussiecommerce.atlassian.net/jira/software/projects/OPEX/boards/106?selectedIssue=OPEX-387)
[www-le-admin](https://github.com/lux-group/www-le-admin/pull/2047)
[svc-reservation](https://github.com/lux-group/svc-reservation/pull/1334)
[svc-reporting](https://github.com/lux-group/svc-reporting/pull/1359)

We are adding new cancellation policy - parnter policy, first 7 days will be allowed to refund to origin or credits 8-21 days refund to credits, > 21 days non-refundable.