### PR TITLE
Deprecate public offer types from lib-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.84",
+  "version": "1.11.0",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.10.83",
+  "version": "1.10.84",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -1,5 +1,8 @@
 import { Tour } from "./tour";
 
+/**
+ * @deprecated Use \@luxuryescapes/contract-public-offer
+ * */
 export namespace PublicOfferV2 {
   interface StrObject {
     [field: string]: string;

--- a/types/api/public-offer.d.ts
+++ b/types/api/public-offer.d.ts
@@ -1,6 +1,9 @@
 import { Geo } from "./geo";
 import { Reservation } from "./reservation";
 
+/**
+ * @deprecated Use \@luxuryescapes/contract-public-offer
+ * */
 export namespace PublicOffer {
   interface Link {
     href: string;


### PR DESCRIPTION
Adds the @deprecated tag to the public-offer types.

This will inform consumers of the API to switch over to the contract version being published via `@luxuryescapes/contract-public-offer`

Bumped the version to 1.13.0 as seems a pretty major (but minor?) change to deprecate whole apis