### PR TITLE
[CONTB-559] Add `isPartnerProperty` instead of `noInclusions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -517,7 +517,7 @@ export namespace PublicOfferV2 {
     roomRates: Record<string, RoomRate>;
     roomTypes: Record<string, RoomType>;
     options: Array<LeHotelOption>;
-    noInclusions?: boolean;
+    isPartnerProperty?: boolean;
   }
 
   interface LeTourOffer extends LeOfferBase {


### PR DESCRIPTION
## Ticket
https://aussiecommerce.atlassian.net/browse/CONTB-559

## Request
Change made because Robert proposed renaming this field.
https://github.com/lux-group/svc-public-offer/pull/1274

## Description
Add `isPartnerProperty` instead of `noInclusions` field for offer.