### PR TITLE
add field to Experiences Offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/experiences.d.ts
+++ b/types/api/experiences.d.ts
@@ -61,6 +61,7 @@ export namespace Experiences {
     meetingPoint?: string;
     needsProviderConfirmation: boolean;
     notes?: string | null;
+    sellerGateway?: string | null;
     offlineBookingInstructions?: string;
     pickupPoints?: Array<PickupPoint>;
     safetyInformation?: SafetyInformation;


### PR DESCRIPTION
Looking forward to a workflow that doesn't involve bumping lib-types version every time we add an API field.
In the meantime, I'll merge this 1-liner without review.