### PR TITLE
EXP-382: create a contract for experiences (contract-svc-experiences)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/experience.d.ts
+++ b/types/api/experience.d.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use \@luxuryescapes/contract-svc-experience
+ * */
 export namespace Experience {
   interface Price {
     currency_code: string;

--- a/types/api/experiences.d.ts
+++ b/types/api/experiences.d.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use \@luxuryescapes/contract-svc-experience
+ * */
 export namespace Experiences {
   type FormItemSchema = {
     name: string;

--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -134,7 +134,7 @@ export namespace Order {
     type: string; // @deprecated
     updated_at: string; // @deprecated
     vendor_id: string; // @deprecated
-    
+
     id: string;
     booking_number: string;
     transaction_key: string;

--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -124,24 +124,67 @@ export namespace Order {
 
   interface ExperienceItem {
     _links: ItemLinks;
-    booking_number: string;
-    created_at: string;
-    currency: string;
-    description: string;
-    detailed_description: string;
-    experience_image: string;
-    external_experience_id: string;
-    fk_order_id: string;
+    created_at: string; // @deprecated
+    description: string; // @deprecated
+    detailed_description: string; // @deprecated
+    experience_image: string; // @deprecated
+    external_experience_id: string; // @deprecated
+    location_text: string; // @deprecated
+    title: string; // @deprecated
+    type: string; // @deprecated
+    updated_at: string; // @deprecated
+    vendor_id: string; // @deprecated
+    
     id: string;
-    location_text: string;
-    status: string;
-    title: string;
-    total: number;
+    booking_number: string;
     transaction_key: string;
-    type: string;
-    updated_at: string;
-    vendor_id: string;
+    fk_order_id: string;
+    provider_offer_id: string;
+    provider_order_id?: string;
+    provider_item_id?: string;
+    le_exclusive?: boolean;
+    language?: string;
+    pickup_point_name?: string;
+    pickup_point_id?: string;
+    meeting_point?: string;
+    customer_info?: CustomerInfoData;
+    cancellation_policies?: CancellationInfo;
+    ticket?: Ticket;
+    max_date_to_provider_confirm?: Date;
+    max_modify_booking_date?: Date;
+    cost_price?: number;
+    sale_price: number;
+    currency: string;
+    total: number;
+    discount_amount?: number;
+    discount_percent?: number;
+    booking_start_date?: Date;
+    expiration_date?: Date;
+    status: "pending" | "completed" | "cancelled" | "processing";
   }
+
+  type Ticket = {
+    fareType: string;
+    identifier: string;
+  };
+
+  type CustomerInfoData = {
+    [key: string]: unknown;
+  };
+
+  type CancellationInfo = {
+    isFree: boolean;
+    refundPolicies?: RefundPolicy[];
+  };
+
+  type RefundPolicy = {
+    id: string;
+    period: string;
+    type: "PERCENTAGE" | "ABSOLUTE";
+    value: number;
+    currencyCode?: string;
+    applicableUntil?: string;
+  };
 
   interface FlightItemLinks extends ItemLinks {
     flight_details: Link;


### PR DESCRIPTION
## STORY TRACKING
Jira: [EXP-382](https://aussiecommerce.atlassian.net/jira/software/projects/EXP/boards/95?assignee=617fca5a327da4006980ee1e&selectedIssue=EXP-382)

## RELATED PRs:
[svc-experiences](https://github.com/lux-group/svc-experiences/pull/82)

## CONTEXT
The activity consists of creating a directory for experience service contracts. For this, a contract was created based on the `experiences.d.ts` file of the [LIB-TYPES](https://github.com/lux-group/lib-types/blob/master/types/api/experiences.d.ts) project.

### SUMMARY OF KEY TECHNICAL CHANGES
A new independent directory has been created within `src/contract` to maintain experience contracts
