### PR TITLE
[OPEX] deprecate reservation types in favor of contract-svc-reservation

### DIFF
--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -1,5 +1,8 @@
 import { Geo } from "./geo";
 
+/**
+ * @deprecated Use \@luxuryescapes/contract-svc-reservation
+ * */
 export namespace Reservation {
   interface Link {
     href: string;


### PR DESCRIPTION
https://github.com/lux-group/svc-reservation/pull/1373
We moved reservation types into contract-svc-reservation, so we deprecating reservation types in this lib.
