### PR TITLE
CRO-263: add the new APIs types on availability and reservation check.

### DIFF
--- a/types/api/reservation.d.ts
+++ b/types/api/reservation.d.ts
@@ -463,4 +463,38 @@ export namespace Reservation {
   interface RatePlansGroupsResult extends Result {
     result: RatePlansGroup[];
   }
+
+  interface RoomAvailabilityEnquiry {
+    room_type_id: string;
+    number_of_nights: number;
+    min_rooms: number;
+  }
+
+  interface RoomAvailabilityResult {
+    enquiry: RoomAvailabilityEnquiry;
+    availabilities: RoomAvailability[];
+  }
+
+  interface RoomAvailability {
+    check_in: string;
+    check_out: string;
+    availability: Availability;
+  }
+
+  interface RoomReservationEnquiry {
+    property_id: string;
+    start_date: string;
+    end_date: string;
+  }
+
+  interface RoomReservationResult {
+    enquiry: RoomReservationEnquiry;
+    room_reservations: RoomReservation[];
+  }
+
+  interface RoomReservation {
+    room_type_id: string;
+    total: number;
+    booking_count: number;
+  }
 }


### PR DESCRIPTION
This patch defines the request and response types for two new APIs in the "svc-reservation" service:

1. One API for getting the availabilities of a given room type. It is expected to return the availabilities of each day, so the offer page can tell whether the room type is "high demands" for each month. This API will also be used to determine whether some room type has "only 3 rooms" available for a given check-in date.

2. One API for getting the total reservation counts of each room type of a given property/hotel within a date range, such as the last three months. It will be used to tell which room type is a "popular room".