### PR TITLE
[OPEX-310] add PriorityPhoneNumber types for svc-graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/discovery.d.ts
+++ b/types/api/discovery.d.ts
@@ -65,4 +65,21 @@ export namespace Discovery {
     currency: string;
     languages: string[];
   }
+  interface PriorityPhoneNumber {
+    code: string;
+    lang: string;
+    name: string;
+    phone_prefix: string;
+    phone: RegionPhone;
+  }
+
+  interface PriorityPhoneNumberResult {
+    result: PriorityPhoneNumbers;
+  }
+
+  interface PriorityPhoneNumbers {
+    priority_phone_numbers: PriorityPhoneNumber[];
+    default_priority_phone_number: PriorityPhoneNumber;
+    current_priority_phone_number: string;
+  }
 }


### PR DESCRIPTION
[Ticket](https://aussiecommerce.atlassian.net/jira/software/projects/OPEX/boards/106?selectedIssue=OPEX-310)

https://github.com/lux-group/lib-regions/pull/212
https://github.com/lux-group/lib-uri-templates/pull/151
https://github.com/lux-group/svc-discovery/pull/252
https://github.com/lux-group/svc-graphql/pull/193

We are providing priority phone numbers for high value orders, I'm adding those similar to regions array but in a separate module to exclude any issues. I declared new api endpoint in lib-uri-templates it will be used by svc-discovery to serve data for svc-graphql.