### PR TITLE
[CRO-376] Add availableRooms attribute into calendar rates API.

### DIFF
--- a/types/api/calendar.d.ts
+++ b/types/api/calendar.d.ts
@@ -7,6 +7,7 @@ export namespace Calendar {
     surcharge: number;
     taxesAndFees: number;
     inclusions: number;
+    availableRooms: number;
   }
 
   interface Price {


### PR DESCRIPTION
### Why is this change happening?
A new attribute `availableRooms` will be provided from the calendar service, which will be used by the customer portal to decide whether the urgency tags should be displayed to the user.

### Summary of the change (from a product/customer perspective)
The new attribute will help the customer portal to decide whether the urgency tags on room type/rate should be shown to the users.

### Summary of key technical changes
Adding the definition of the `availableRooms` attribute into the calendar rates API response.

### Related JIRA ticket (if one exists)
[CRO-376](https://aussiecommerce.atlassian.net/browse/CRO-376)