### PR TITLE
Make two fields optional due to api upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/bedbank.d.ts
+++ b/types/api/bedbank.d.ts
@@ -27,6 +27,8 @@ export namespace Bedbank {
   interface OccupancyFee {
     type: string;
     amount: number;
+    scope?: string;
+    frequency?: string;
   }
 
   interface ReservationRoom {

--- a/types/api/bedbank.d.ts
+++ b/types/api/bedbank.d.ts
@@ -27,8 +27,6 @@ export namespace Bedbank {
   interface OccupancyFee {
     type: string;
     amount: number;
-    scope: string;
-    frequency: string;
   }
 
   interface ReservationRoom {

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -46,8 +46,6 @@ export namespace PublicOfferV2 {
   interface OccupancyFee {
     type: string;
     amount: number;
-    scope: string;
-    frequency: string;
   }
 
   interface RateOccupancyPricing {

--- a/types/api/public-offer-v2.d.ts
+++ b/types/api/public-offer-v2.d.ts
@@ -46,6 +46,8 @@ export namespace PublicOfferV2 {
   interface OccupancyFee {
     type: string;
     amount: number;
+    scope?: string;
+    frequency?: string;
   }
 
   interface RateOccupancyPricing {


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/CONLT-175?atlOrigin=eyJpIjoiNGUzYjc5ZmY1ZDIzNDNlZDkyMzJmNjBiYjI5NWJkZTAiLCJwIjoiaiJ9

the api upgrade pr is https://github.com/lux-group/svc-bedbank/pull/1050

Thinking I'll make it optional instead of removing those for now given clients like public offer svc are using objectWithOnly, so I'll keep these as optional there just in case