### PR TITLE
EXP-610: add provider to order experience item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.14.14",
+  "version": "1.14.15",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -144,6 +144,7 @@ export namespace Order {
     provider_offer_id: string;
     provider_order_id?: string;
     provider_item_id?: string;
+    provider: string;
     le_exclusive?: boolean;
     language?: string;
     pickup_point_name?: string;


### PR DESCRIPTION
##Description
Needs to add experience provider to admin portal

## Related PR's
[www-le-admin](https://github.com/lux-group/www-le-admin/pull/2257)
[svc-order](https://github.com/lux-group/svc-order/pull/2135)