### PR TITLE
Add new status types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -4,7 +4,7 @@ export namespace Referral {
   /**
    * Aligns with the 'referral_log_status' db enum
    */
-  type LogStatus = "pending" | "redeeming" | "redeemed";
+  type LogStatus = "pending" | "available" | "redeemed";
 
   /**
    * Used to match Referral Log Types in the db to type of Earn Option
@@ -62,6 +62,7 @@ export namespace Referral {
     log_status: LogStatus;
     earn_amount?: string;
     first_name?: string;
+    available_by?: string;
   }
 
   interface RedeemReferralRewardBody {

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -2,10 +2,17 @@
 
 export namespace Referral {
   /**
-   * Aligns with the 'referral_log_status' db enum
+   * The status of the referral log
+   *
+   * 'pending_cooldown', 'pending_selection', & 'redeeming' have been depreciated
    */
-  type LogStatus = "pending_cooldown"|"pending_selection"|"redeeming"| // Old (to be removed)
-  "pending" | "available" | "redeemed"; // New
+  type LogStatus =
+    | "pending_cooldown"
+    | "pending_selection"
+    | "redeeming"
+    | "pending"
+    | "available"
+    | "redeemed";
 
   /**
    * Used to match Referral Log Types in the db to type of Earn Option
@@ -47,7 +54,7 @@ export namespace Referral {
     available: number;
     redeemed: number;
     redeeming: number;
-    total_amount_redeemed: number
+    total_amount_redeemed: number;
   }
 
   interface ReferralLog {

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -4,7 +4,8 @@ export namespace Referral {
   /**
    * Aligns with the 'referral_log_status' db enum
    */
-  type LogStatus = "pending" | "available" | "redeemed";
+  type LogStatus = "pending_cooldown"|"pending_selection"|"redeeming"| // Old (to be removed)
+  "pending" | "available" | "redeemed"; // New
 
   /**
    * Used to match Referral Log Types in the db to type of Earn Option
@@ -46,12 +47,7 @@ export namespace Referral {
     available: number;
     redeemed: number;
     redeeming: number;
-    total_amount_redeemed: RedeemSum[];
-  }
-
-  interface RedeemSum {
-    kind: EarnTypeCode;
-    sum: number;
+    total_amount_redeemed: number
   }
 
   interface ReferralLog {

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -4,10 +4,7 @@ export namespace Referral {
   /**
    * Aligns with the 'referral_log_status' db enum
    */
-  type LogStatus =
-    | "pending"
-    | "redeeming"
-    | "redeemed";
+  type LogStatus = "pending" | "redeeming" | "redeemed";
 
   /**
    * Used to match Referral Log Types in the db to type of Earn Option

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -5,8 +5,7 @@ export namespace Referral {
    * Aligns with the 'referral_log_status' db enum
    */
   type LogStatus =
-    | "pending_cooldown"
-    | "pending_selection"
+    | "pending"
     | "redeeming"
     | "redeemed";
 


### PR DESCRIPTION
Add new, simpler, status types

Note: total_amount_redeemed is currently being returned as a number and lib-types is being updated to reflect that

Required for: 
- https://github.com/lux-group/svc-promo/pull/315
- https://github.com/lux-group/www-le-customer/pull/7880