### PR TITLE
[OPEX-578] insurance type update, add status_reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -220,6 +220,7 @@ export namespace Order {
 
   interface InsuranceItem extends Item {
     _links: InsuranceItemLinks;
+    status_reason: string;
   }
 
   interface AccommodationItemLinks extends ItemLinks {


### PR DESCRIPTION
We need to add status_reason to filter out cancelled insurances due to them being upgraded. 