### PR TITLE
MP-1050-Make-API-Changes-non-breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -5,13 +5,13 @@ export namespace Referral {
    * The status of the referral log
    *
    * 'pending_cooldown' - Waiting for earn cooldown to complete
-   * 
+   *
    * 'pending_selection' - Waiting for earn selection to be made
-   * 
+   *
    * 'redeeming' - Earn redemption in progress (deprecated)
-   * 
+   *
    * 'redeemed' - Earn redemption successful
-   * 
+   *
    */
   type LogStatus =
     | "pending_cooldown"
@@ -60,7 +60,7 @@ export namespace Referral {
     /** Total # of successful completed referral events */
     total_amount_redeemed: number;
     /** Total credits earn via the referral system */
-    creditsRedeemed: number; 
+    creditsRedeemed: number;
   }
 
   interface ReferralLog {

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -4,14 +4,19 @@ export namespace Referral {
   /**
    * The status of the referral log
    *
-   * 'pending_cooldown', 'pending_selection', & 'redeeming' have been depreciated
+   * 'pending_cooldown' - Waiting for earn cooldown to complete
+   * 
+   * 'pending_selection' - Waiting for earn selection to be made
+   * 
+   * 'redeeming' - Earn redemption in progress (deprecated)
+   * 
+   * 'redeemed' - Earn redemption successful
+   * 
    */
   type LogStatus =
     | "pending_cooldown"
     | "pending_selection"
     | "redeeming"
-    | "pending"
-    | "available"
     | "redeemed";
 
   /**
@@ -29,7 +34,6 @@ export namespace Referral {
 
   interface GetReferralEarnOptionsResponse {
     status: number;
-    success: boolean;
     region: string;
     brand: string;
     referral_log_id: string;
@@ -41,7 +45,6 @@ export namespace Referral {
 
   interface GetReferralLogsResponse {
     status: number;
-    success: boolean;
     message?: string;
     result: {
       referral_logs: ReferralLog[];
@@ -50,11 +53,14 @@ export namespace Referral {
   }
 
   interface ReferralLogTotal {
+    /** Total # of referral events awaiting cooldown  */
     pending: number;
-    available: number;
-    redeemed: number;
-    redeeming: number;
+    /** Total # of referral events for earn selection */
+    available_referrals: number;
+    /** Total # of successful completed referral events */
     total_amount_redeemed: number;
+    /** Total credits earn via the referral system */
+    creditsRedeemed: number; 
   }
 
   interface ReferralLog {


### PR DESCRIPTION
Avoid breaking API changes through restoring the orignal types & API Response shape

Paired with: 
https://github.com/lux-group/svc-promo/pull/315

 