### PR TITLE
Mp 1141 add google tracking params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -33,6 +33,27 @@ export namespace Referral {
     };
   }
 
+  // Get Referral Code By User
+
+  type ReferralUTMParams = {
+    utm_campaign?: string;
+    utm_content?: string;
+  };
+
+  // We need this as the '_link' param sits outside of the 'result' object
+  interface GetCodeByUserIdApiResponse
+    extends ApiResponse<GetCodeByUserIdResult> {
+    _link: string;
+  }
+
+  interface GetCodeByUserIdResult {
+    referral_code_id: string;
+    id_user: string;
+    referral_code: string;
+    created_at: string;
+    referral_utm_params?: ReferralUTMParams;
+  }
+
   // Refereee Value
 
   type ReferreeValueType = "fixed_amount" | "percentage";
@@ -54,12 +75,6 @@ export namespace Referral {
     type: ReferreeValueType;
     min_spend: number;
     product_type_discount: ProductTypeDiscount[];
-    referral_utm_params: ReferralUTMParams;
-  };
-
-  type ReferralUTMParams = {
-    utm_campaign?: string;
-    utm_content?: string;
   };
 
   // Referral Log

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -35,7 +35,7 @@ export namespace Referral {
 
   // Get Referral Code By User
 
-  type ReferralUTMParams = {
+  type UTMParams = {
     utm_campaign?: string;
     utm_content?: string;
   };
@@ -48,14 +48,15 @@ export namespace Referral {
 
   interface GetCodeByUserIdResult {
     details: GetCodeByUserIdDetails;
-    meta_data: ReferralUTMParams;
+    meta_data: UTMParams;
   }
+
   interface GetCodeByUserIdDetails {
     referral_code_id: string;
     id_user: string;
     referral_code: string;
     created_at: string;
-    referral_utm_params?: ReferralUTMParams;
+    referral_utm_params?: UTMParams;
   }
 
   // Refereee Value

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -22,10 +22,7 @@ export namespace Referral {
     summary?: string;
   }
 
-  type ReferralUTMParams = {
-    utm_campaign?: string;
-    utm_content?: string;
-  };
+
 
   interface GetReferralEarnOptionsResponse {
     status: number;
@@ -35,8 +32,25 @@ export namespace Referral {
     user_id: string;
     result: {
       earn_options: EarnOption[];
-      ReferralUTMParams?: ReferralUTMParams;
     };
+  }
+
+  type ReferralUTMParams = {
+    utm_campaign?: string;
+    utm_content?: string;
+  };
+
+  interface GetCodeByUserIdApiResponse
+    extends ApiResponse<GetCodeByUserIdResult> {
+    _link: string;
+  }
+
+  interface GetCodeByUserIdResult {
+    referral_code_id: string;
+    id_user: string;
+    referral_code: string;
+    created_at: string;
+    referral_utm_params?: ReferralUTMParams;
   }
 
   // Refereee Value

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -22,8 +22,6 @@ export namespace Referral {
     summary?: string;
   }
 
-
-
   interface GetReferralEarnOptionsResponse {
     status: number;
     region: string;
@@ -34,6 +32,8 @@ export namespace Referral {
       earn_options: EarnOption[];
     };
   }
+
+  // Get Referral Code By User
 
   type ReferralUTMParams = {
     utm_campaign?: string;

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -40,6 +40,7 @@ export namespace Referral {
     utm_content?: string;
   };
 
+  // We need this as the '_link' param sits outside of the 'result' object
   interface GetCodeByUserIdApiResponse
     extends ApiResponse<GetCodeByUserIdResult> {
     _link: string;

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -33,27 +33,6 @@ export namespace Referral {
     };
   }
 
-  // Get Referral Code By User
-
-  type ReferralUTMParams = {
-    utm_campaign?: string;
-    utm_content?: string;
-  };
-
-  // We need this as the '_link' param sits outside of the 'result' object
-  interface GetCodeByUserIdApiResponse
-    extends ApiResponse<GetCodeByUserIdResult> {
-    _link: string;
-  }
-
-  interface GetCodeByUserIdResult {
-    referral_code_id: string;
-    id_user: string;
-    referral_code: string;
-    created_at: string;
-    referral_utm_params?: ReferralUTMParams;
-  }
-
   // Refereee Value
 
   type ReferreeValueType = "fixed_amount" | "percentage";
@@ -75,6 +54,12 @@ export namespace Referral {
     type: ReferreeValueType;
     min_spend: number;
     product_type_discount: ProductTypeDiscount[];
+    referral_utm_params: ReferralUTMParams;
+  };
+
+  type ReferralUTMParams = {
+    utm_campaign?: string;
+    utm_content?: string;
   };
 
   // Referral Log

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -47,6 +47,10 @@ export namespace Referral {
   }
 
   interface GetCodeByUserIdResult {
+    details: GetCodeByUserIdDetails;
+    meta_data: ReferralUTMParams;
+  }
+  interface GetCodeByUserIdDetails {
     referral_code_id: string;
     id_user: string;
     referral_code: string;

--- a/types/api/referral.d.ts
+++ b/types/api/referral.d.ts
@@ -22,6 +22,11 @@ export namespace Referral {
     summary?: string;
   }
 
+  type ReferralUTMParams = {
+    utm_campaign?: string;
+    utm_content?: string;
+  };
+
   interface GetReferralEarnOptionsResponse {
     status: number;
     region: string;
@@ -30,6 +35,7 @@ export namespace Referral {
     user_id: string;
     result: {
       earn_options: EarnOption[];
+      ReferralUTMParams?: ReferralUTMParams;
     };
   }
 


### PR DESCRIPTION
- To better track how changes to referral configuration is impacting the rate of referrals, include current 'Referral GTM params' in the existing GetReferralCodeById API response
- Type the (existing) getCodeByUserId response