### PR TITLE
Adding package status to offer from svc-offer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-types",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "types": "types/index.d.ts",
   "repository": "git@github.com:brandsExclusive/lib-types.git",
   "author": "Rufus Post <rufuspost@gmail.com>",

--- a/types/api/offer.d.ts
+++ b/types/api/offer.d.ts
@@ -95,6 +95,8 @@ export namespace Offer {
     regions: string[];
   }
 
+  type AccommodationPackageStatusType = "content-approved" | "draft";
+
   interface AccommodationPackage extends BasePackage {
     fk_property_id: string;
     fk_room_rate_id: string;
@@ -104,6 +106,7 @@ export namespace Offer {
     max_days_in_future_check_in_is_allowed: number | undefined;
     number_of_nights: number;
     package_options: PackageOption[];
+    status?: AccommodationPackageStatusType;
   }
 
   interface TourPackage extends BasePackage {


### PR DESCRIPTION
Reason for this change: svc-offer also sends package status which identifies whether a package is approved

https://github.com/lux-group/svc-offer/blob/master/src/api/v1/presenters/roomTypePackagesPresenter.test.js#L18