### PR TITLE
make response json flexible

### DIFF
--- a/types/api/payment.d.ts
+++ b/types/api/payment.d.ts
@@ -28,6 +28,8 @@ export namespace Payment {
   }
 
   interface ResponseJson {
-    [property: string]: string | number | boolean | null;
+    // This is a dynamic response from payment providers like Stripe, PayPal etc
+    // The shape varies completely between providers and can be deeply nested
+    [key: string]: unknown;
   }
 }


### PR DESCRIPTION
This represents the response json payload from taking a payment - and it may come from various different providers (Stripe, paypal, klarna, etc) so the response shape can vary a lot between providers, and even within one provider (depending on if the payment passed or failed etc).

And, the response json can have nested objects. So, the current type doesn't work.

This has come up as a problem in the context of this pr / commit: https://github.com/lux-group/www-le-admin/pull/5628/commits/f95314914928f0a308d93320f4f1a82d5217295d